### PR TITLE
bank spells json

### DIFF
--- a/src/json/Kunark_Velious Spells - Bard Songs.json
+++ b/src/json/Kunark_Velious Spells - Bard Songs.json
@@ -1,0 +1,20 @@
+[
+  {
+    "level": 50,
+    "name": "Melody of Ervaj",
+    "count": 0,
+    "banker*": ""
+  },
+  {
+    "level": 55,
+    "name": "Occlusion of Sound",
+    "count": 3,
+    "banker*": "Cgkxclass"
+  },
+  {
+    "level": 60,
+    "name": "Composition of Ervaj",
+    "count": 11,
+    "banker*": "Cgkxclass"
+  }
+]

--- a/src/json/Kunark_Velious Spells - Cleric Spells.json
+++ b/src/json/Kunark_Velious Spells - Cleric Spells.json
@@ -1,0 +1,149 @@
+[
+  {
+    "level": "51",
+    "name": "Improved Invis to Undead",
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": "51",
+    "name": "Sunskin",
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": "52",
+    "name": "Heroic Bond",
+    "banker": "Cgkcleric",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": "52",
+    "name": "Word of Vigor",
+    "banker": "Cgkcleric",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": "52",
+    "name": "Upheaval",
+    "banker": "Cgkxclass",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": "53",
+    "name": "Yaulp IV",
+    "banker": "Cgkxclass",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": "54",
+    "name": "Reckoning",
+    "banker": "Cgkcleric",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": "54",
+    "name": "Unswerving Hammer",
+    "banker": "Cgkcleric",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": "55",
+    "name": "Fortitude",
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": "55",
+    "name": "Stun Command",
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": "55",
+    "name": "Wake of Tranquility",
+    "banker": "Cgkxclass",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": "56",
+    "name": "Mark of Karn",
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": "57",
+    "name": "Aegis",
+    "banker": "Cgkcleric",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": "57",
+    "name": "Word of Restoration",
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": "58",
+    "name": "Enforced Reverence",
+    "banker": "Cgkcleric",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": "58",
+    "name": "Naltron's Mark",
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": "59",
+    "name": "The Unspoken Word",
+    "banker": "Cgkcleric",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": "60",
+    "name": "Aegolism",
+    "banker": "Cgkcleric",
+    "cost": "DKP Auction only",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": "60",
+    "name": "Banishment of Shadows",
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": "60",
+    "name": "Divine Intervention",
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": "60",
+    "name": "Word of Redemption",
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  }
+]

--- a/src/json/Kunark_Velious Spells - Druid Spells.json
+++ b/src/json/Kunark_Velious Spells - Druid Spells.json
@@ -1,0 +1,218 @@
+[
+  {
+    "level": 50,
+    "name": "Improved Superior Camouflage",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "last updated": ""
+  },
+  {
+    "level": 51,
+    "name": "Circle of Winter",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "last updated": ""
+  },
+  {
+    "level": 51,
+    "name": "Upheaval",
+    "count": 11,
+    "banker": "Cgkxclass",
+    "cost": "50p",
+    "last updated": "4/14/2022"
+  },
+  {
+    "level": 52,
+    "name": "Call of Karana",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "last updated": ""
+  },
+  {
+    "level": 52,
+    "name": "Circle of Summer",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "last updated": ""
+  },
+  {
+    "level": 52,
+    "name": "Egress",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "last updated": ""
+  },
+  {
+    "level": 53,
+    "name": "Glamour of Tunare",
+    "count": 1,
+    "banker": "Cgkdruid",
+    "cost": "50p",
+    "last updated": "4/14/2022"
+  },
+  {
+    "level": 53,
+    "name": "Spirit of Scale",
+    "count": 1,
+    "banker": "Cgkxclass",
+    "cost": "50p",
+    "last updated": "4/14/2022"
+  },
+  {
+    "level": 54,
+    "name": "Blizzard",
+    "count": 16,
+    "banker": "Cgkdruid",
+    "cost": "50p",
+    "last updated": "4/14/2022"
+  },
+  {
+    "level": 54,
+    "name": "Form of the Howler",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "last updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Girdle of Karana",
+    "count": 3,
+    "banker": "Cgkdruid",
+    "cost": "200p OR 1DKP",
+    "last updated": "4/14/2022"
+  },
+  {
+    "level": 55,
+    "name": "Nature Walkers Behest",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "last updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Tunare's Request",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "last updated": ""
+  },
+  {
+    "level": 56,
+    "name": "Breath of Karana",
+    "count": 5,
+    "banker": "Cgkdruid",
+    "cost": "200p OR 1DKP",
+    "last updated": "4/14/2022"
+  },
+  {
+    "level": 56,
+    "name": "Wake of Karana",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "last updated": ""
+  },
+  {
+    "level": 57,
+    "name": "Bonds of Tunare",
+    "count": 1,
+    "banker": "Cgkdruid",
+    "cost": "200p OR 1DKP",
+    "last updated": "4/14/2022"
+  },
+  {
+    "level": 57,
+    "name": "Frost",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "last updated": ""
+  },
+  {
+    "level": 57,
+    "name": "Succor",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "last updated": ""
+  },
+  {
+    "level": 58,
+    "name": "Fist of Karana",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "last updated": ""
+  },
+  {
+    "level": 58,
+    "name": "Regrowth of the Grove",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "last updated": ""
+  },
+  {
+    "level": 59,
+    "name": "Legacy of Thorn",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "last updated": ""
+  },
+  {
+    "level": 59,
+    "name": "Spirit of Oak",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "last updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Banishment",
+    "count": 7,
+    "banker": "Cgkmagi",
+    "cost": "200p OR 1DKP",
+    "last updated": "4/14/2022"
+  },
+  {
+    "level": 60,
+    "name": "Entrapping Roots",
+    "count": 4,
+    "banker": "Cgkdruid",
+    "cost": "DKP Auction only",
+    "last updated": "4/14/2022"
+  },
+  {
+    "level": 60,
+    "name": "Form of the Hunter",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "last updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Mask of the Hunter",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "last updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Protection of the Glades",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "last updated": ""
+  }
+]

--- a/src/json/Kunark_Velious Spells - Enchanter Spells.json
+++ b/src/json/Kunark_Velious Spells - Enchanter Spells.json
@@ -1,0 +1,202 @@
+[
+  {
+    "level": 50,
+    "name": "Improved Invisibility",
+    "count": 1,
+    "banker": "Cgkxclass",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 51,
+    "name": "Theft of Thought",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 51,
+    "name": "Wake of Tranquility",
+    "count": 12,
+    "banker": "Cgkxclass",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 52,
+    "name": "Boon of the Clear Mind",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 52,
+    "name": "Color Slant",
+    "count": 3,
+    "banker": "Cgkench",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 53,
+    "name": "Cripple",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 53,
+    "name": "Recant Magic",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 54,
+    "name": "Clarity II",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 54,
+    "name": "Dementia",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Gift of Insight",
+    "count": 5,
+    "banker": "Cgkench",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 55,
+    "name": "Largarn's Lamentation",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Wind of Tishani",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Zumaik's Animation",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 56,
+    "name": "Augment",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 56,
+    "name": "Torment of Argli",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 57,
+    "name": "Enlightenment",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 57,
+    "name": "Forlorn Deeds",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 57,
+    "name": "Umbra",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 58,
+    "name": "Bedlam",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 59,
+    "name": "Asphyxiate",
+    "count": 1,
+    "banker": "Cgkench",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 59,
+    "name": "Gift of Pure Thought",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Dictate",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Gift of Brilliance",
+    "count": 1,
+    "banker": "Cgkench",
+    "cost": "DKP Auction only",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 60,
+    "name": "Visions of Grandeur",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Wind of Tishanian",
+    "count": 7,
+    "banker": "Cgkench",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  }
+]

--- a/src/json/Kunark_Velious Spells - Magician Spells.json
+++ b/src/json/Kunark_Velious Spells - Magician Spells.json
@@ -1,0 +1,218 @@
+[
+  {
+    "level": 50,
+    "name": "Monster Summoning II",
+    "count": 4,
+    "banker": "Cgkmagi",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 51,
+    "name": "Gift of Xev",
+    "count": 6,
+    "banker": "Cgkmagi",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 51,
+    "name": "Scintillation",
+    "count": 4,
+    "banker": "Cgkmagi",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 52,
+    "name": "Bristlebane's Bundle",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 53,
+    "name": "Boon of Immolation",
+    "count": 3,
+    "banker": "Cgkmagi",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 53,
+    "name": "Quiver of Marr",
+    "count": 7,
+    "banker": "Cgkmagi",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 53,
+    "name": "Vocarate: Fire",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 54,
+    "name": "Bandoleer of Luclin",
+    "count": 10,
+    "banker": "Cgkmagi",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 54,
+    "name": "Scars of Sigil",
+    "count": 5,
+    "banker": "Cgkmagi",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 54,
+    "name": "Vocarate: Air",
+    "count": 2,
+    "banker": "Cgkmagi",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 55,
+    "name": "Burnout IV",
+    "count": 1,
+    "banker": "Cgkmagi",
+    "cost": "DKP Auction only",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 55,
+    "name": "Call of the Hero",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Pouch of Quellious",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Rage of Zomm",
+    "count": 3,
+    "banker": "Cgkmagi",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 55,
+    "name": "Wrath of the Elements",
+    "count": 9,
+    "banker": "Cgkmagi",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 56,
+    "name": "Dyzil's Deafening Decoy",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 56,
+    "name": "Muzzle of Mardu",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 57,
+    "name": "Eye of Tallon",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 58,
+    "name": "Greater Vocaration: Fire",
+    "count": 1,
+    "banker": "Cgkmagi",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 59,
+    "name": "Velocity",
+    "count": 6,
+    "banker": "Cgkmagi",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 59,
+    "name": "Greater Vocaration: Air",
+    "count": 6,
+    "banker": "Cgkmagi",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 59,
+    "name": "Manastorm",
+    "count": 11,
+    "banker": "Cgkmagi",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 60,
+    "name": "Aegis of Ro",
+    "count": 4,
+    "banker": "Cgkmagi",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 60,
+    "name": "Banishment",
+    "count": 7,
+    "banker": "Cgkmagi",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 60,
+    "name": "Greater Vocaration: Water",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Mala",
+    "count": 7,
+    "banker": "Cgkmagi",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 60,
+    "name": "Monster Summoning III",
+    "count": 4,
+    "banker": "Cgkmagi",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  }
+]

--- a/src/json/Kunark_Velious Spells - Necromancer Spells.json
+++ b/src/json/Kunark_Velious Spells - Necromancer Spells.json
@@ -1,0 +1,210 @@
+[
+  {
+    "level": 50,
+    "name": "Improved Invis to Undead",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 51,
+    "name": "Sacrifice",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 51,
+    "name": "Splurt",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 52,
+    "name": "Defoliation",
+    "count": 1,
+    "banker": "Cgknecro",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 52,
+    "name": "Scent of Terris",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 53,
+    "name": "Convergence",
+    "count": 1,
+    "banker": "Cgknecro",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 53,
+    "name": "Minion of Shadows",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 54,
+    "name": "Shadowbond",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 54,
+    "name": "Thrall of Bones",
+    "count": 1,
+    "banker": "Cgknecro",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 55,
+    "name": "Augmentation of Death",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Chill Bones",
+    "count": 7,
+    "banker": "Cgknecro",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 55,
+    "name": "Conglaciation of Bone",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Infusion",
+    "count": 11,
+    "banker": "Cgknecro",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 55,
+    "name": "Levant",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 56,
+    "name": "Sedulous Subversion",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 56,
+    "name": "Servant of Bones",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 57,
+    "name": "Conjure Corpse",
+    "count": 1,
+    "banker": "Cgknecro",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 58,
+    "name": "Quivering Veil of Xarn",
+    "count": 14,
+    "banker": "Cgknecro",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 59,
+    "name": "Devouring Darkness",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 59,
+    "name": "Emissary of Thule",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Arch Lich",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Banishment of Shadows",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Demi Lich",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Enslave Death",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Gangrenous Touch of Zum'uul",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Trucidation",
+    "count": 2,
+    "banker": "Cgknecro",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  }
+]

--- a/src/json/Kunark_Velious Spells - Shaman Spells.json
+++ b/src/json/Kunark_Velious Spells - Shaman Spells.json
@@ -1,0 +1,218 @@
+[
+  {
+    "level": 50,
+    "name": "Spirit Quickening",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 51,
+    "name": "Talisman of Jasinth",
+    "count": 4,
+    "banker": "",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 52,
+    "name": "Insidious Decay",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 52,
+    "name": "Spirit of Scale",
+    "count": 1,
+    "banker": "Cgkxclass",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 53,
+    "name": "Cripple",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 53,
+    "name": "Talisman of Shadoo",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 54,
+    "name": "Cannibalize III",
+    "count": 4,
+    "banker": "Cgkshaman",
+    "cost": "50p",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 54,
+    "name": "Shroud of the Spirits",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Form of the Great Bear",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Spirit of the Howler",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 55,
+    "name": "Torrent of Poison",
+    "count": 3,
+    "banker": "Cgkshaman",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 56,
+    "name": "Acumen",
+    "count": 12,
+    "banker": "Cgkshaman",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 55,
+    "name": "Bane of Nife",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 57,
+    "name": "Talisman of the Brute",
+    "count": 1,
+    "banker": "Cgkshaman",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 57,
+    "name": "Talisman of the Cat",
+    "count": 1,
+    "banker": "Cgkshaman",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 58,
+    "name": "Cannibalize IV",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 58,
+    "name": "Talisman of the Rhino",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 58,
+    "name": "Talisman of the Serpent",
+    "count": 1,
+    "banker": "Cgkshaman",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 58,
+    "name": "Tigir's Insects",
+    "count": 0,
+    "banker": "",
+    "cost": "50p",
+    "updated": ""
+  },
+  {
+    "level": 59,
+    "name": "Pox of Bertoxxulous",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 59,
+    "name": "Talisman of the Raptor",
+    "count": 1,
+    "banker": "Cgkshaman",
+    "cost": "200p OR 1DKP",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 59,
+    "name": "Voice of the Berserker",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Avatar",
+    "count": 1,
+    "banker": "Cgkshaman",
+    "cost": "DKP Auction only",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 60,
+    "name": "Focus of Spirit",
+    "count": 5,
+    "banker": "Cgkshaman",
+    "cost": "DKP Auction only",
+    "updated": "4/14/2022"
+  },
+  {
+    "level": 60,
+    "name": "Malo",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Primal Avatar",
+    "count": 0,
+    "banker": "",
+    "cost": "200p OR 1DKP",
+    "updated": ""
+  },
+  {
+    "level": 60,
+    "name": "Torpor",
+    "count": 0,
+    "banker": "",
+    "cost": "DKP Auction only",
+    "updated": ""
+  }
+]


### PR DESCRIPTION
adds json data for banked spells. these are intended to be a shim until a more robust db solution is in place. the 'count' and 'updated' values are already out of date and should not be used yet.