### PR TITLE
Sort first available bots by bind location

### DIFF
--- a/src/services/bot/bot-prisma.ts
+++ b/src/services/bot/bot-prisma.ts
@@ -78,7 +78,7 @@ export class PrismaPublicAccounts implements IPublicAccountService {
     location?: string | undefined,
     bindLocation?: string | undefined
   ): Promise<string> {
-    const query = {
+    const bot = await this.prisma.bot.findFirst({
       where: {
         class: botClass,
         currentPilot: "",
@@ -88,9 +88,10 @@ export class PrismaPublicAccounts implements IPublicAccountService {
         ...(location ? { location: location } : {}),
         ...(bindLocation ? { bindLocation: bindLocation } : {}),
       },
-    };
-
-    const bot = await this.prisma.bot.findFirst(query);
+      orderBy: {
+        bindLocation: "desc",
+      },
+    });
     const locationString = location ? ` in ${location}` : "";
     if (bot && bot.name) {
       log(


### PR DESCRIPTION
Bealls request to get TOV bots first, this is the simplest way since TOV should be the last alphabetical bind location for most bots