### PR TITLE
test: add Discord.js mocks and example tests

### DIFF
--- a/src/features/applications/request-application-button-commands.test.ts
+++ b/src/features/applications/request-application-button-commands.test.ts
@@ -1,0 +1,98 @@
+import { RequestApplication } from "./request-application-button-commands";
+import { setupApplicationTest } from "../../test/helpers/test-setup";
+import { createMockGuild } from "../../test/mocks/create-mock-guild";
+import { createMockButtonInteraction } from "../../test/mocks/create-mock-button-interaction";
+import { asButtonInteraction } from "../../test/utils/discord-conversions";
+import { executeButtonCommand } from "../../test/helpers/execution-helpers";
+import { MessageCreateOptions } from "discord.js";
+
+jest.mock("../../config", () => ({
+  requestDumpThreadId: "111222333",
+}));
+
+describe("RequestApplication", () => {
+  let requestApplication: RequestApplication;
+
+  beforeEach(() => {
+    requestApplication = new RequestApplication();
+  });
+
+  describe("execute", () => {
+    it("should send DM to user and log to request dump channel", async () => {
+      const { interaction, threadChannel } = setupApplicationTest();
+      const resolvedThreadChannel = await threadChannel;
+
+      await requestApplication.execute(asButtonInteraction(interaction));
+
+      expect(interaction.user).toHaveSentDm(/DO NOT REPLY TO THIS MESSAGE/);
+      expect(interaction).toHaveEditedReply(
+        "You have been DM'd the **Volunteer Application**."
+      );
+      expect(resolvedThreadChannel).toHaveSentMessage(
+        `Volunteer Application sent to **${interaction.user.username}** (<@${interaction.user.id}>)`
+      );
+    });
+
+    it("should throw error if request dump channel not found", async () => {
+      const guild = createMockGuild({ threadChannels: [] });
+      const interaction = createMockButtonInteraction({ guild });
+
+      await expect(
+        requestApplication.execute(asButtonInteraction(interaction))
+      ).rejects.toThrow("Could not locate the request dump channel");
+    });
+
+    it("should throw error if channel is not a public thread", async () => {
+      const guild = createMockGuild({
+        textChannels: [{ id: "111222333" }], // Wrong channel type
+      });
+      const interaction = createMockButtonInteraction({ guild });
+
+      await expect(
+        requestApplication.execute(asButtonInteraction(interaction))
+      ).rejects.toThrow("111222333 is not a text channel");
+    });
+  });
+
+  describe("label", () => {
+    it("should return correct label", () => {
+      expect(requestApplication.label).toBe("Volunteer Application");
+    });
+  });
+
+  describe("getButtonBuilder", () => {
+    it("should create button with correct properties", () => {
+      const buttonBuilder = requestApplication.getButtonBuilder(1); // ButtonStyle.Primary
+
+      expect(buttonBuilder).toHaveCustomId("volunteer-application");
+      expect(buttonBuilder).toHaveLabel("Volunteer Application");
+      expect(buttonBuilder.data.style).toBe(1);
+    });
+  });
+
+  describe("content", () => {
+    it("should contain required application information", async () => {
+      const { interaction } = setupApplicationTest();
+
+      await requestApplication.execute(asButtonInteraction(interaction));
+
+      const dmCall = interaction.user.send.mock.calls[0][0];
+      const content =
+        typeof dmCall === "string" ? dmCall : (dmCall as any).content;
+
+      expect(content).toContain("DO NOT REPLY TO THIS MESSAGE");
+      expect(content).toContain("How do I apply?");
+      expect(content).toContain(
+        "https://docs.google.com/forms/d/e/1FAIpQLSelYSgoouJCOIV9qoOQ1FdOXj8oGC2pfv7P47iUUd1hjOic-g/viewform"
+      );
+      expect(content).toContain("What happens to an application?");
+      expect(content).toContain("less than a week");
+    });
+  });
+
+  describe("customId", () => {
+    it("should inherit customId from ButtonCommand constructor", () => {
+      expect(requestApplication.customId).toBe("volunteer-application");
+    });
+  });
+});

--- a/src/features/applications/update-applications.fixture.ts
+++ b/src/features/applications/update-applications.fixture.ts
@@ -1,0 +1,22 @@
+export const volunteerApplicationsEmbed = {
+  title: "Volunteer Applications",
+  description: `Castle is a casual-friendly guild and that applies to volunteer and leadership roles as well. We have many volunteer roles that help keep the guild running smoothly.
+
+❓ **What do volunteers do?**
+• Read about each [volunteer role](https://docs.google.com/document/d/19fqGGGAW3tXTPb8syiCZQZED9qTGhY65dnaWL8YzZnE).
+
+❓ **What's expected of volunteers?**
+• Represent us well, both internally and externally.
+• Commit as much time as you like, when you'd like.
+• You may take a break or step down at any time, but you will be required to re-apply if you become interested again.
+
+❓ **Am I a good candidate to volunteer? What if I'm an ally?**
+• Yes! Everyone is encouraged to volunteer.
+• All roles are open to alliance members except :red_square: **Officer** and :red_square: **Guard**, which are Castle-members only.
+
+📜 **How do I apply?**
+• Press the button below to receive a link to the volunteer application in a DM.
+• Retrieving the application is not a commitment to apply!
+
+✨ _"Many hands make light work!"_ ✨`,
+};

--- a/src/features/applications/update-applications.test.ts
+++ b/src/features/applications/update-applications.test.ts
@@ -1,0 +1,121 @@
+import {
+  UpdateApplicationInfoAction,
+  updateApplicationInfo,
+} from "./update-applications";
+import { createMockClient } from "../../test/mocks/create-mock-client";
+import { asClient } from "../../test/utils/discord-conversions";
+import { volunteerApplicationsEmbed } from "./update-applications.fixture";
+import { Client, ButtonStyle } from "discord.js";
+
+jest.mock("../../config", () => ({
+  applicationsChannelId: "999888777",
+}));
+
+// Mock the base class methods
+const mockCreateOrUpdateInstructions = jest.fn();
+const mockGetChannel = jest.fn();
+
+jest.mock("../../shared/action/instructions-ready-action", () => ({
+  InstructionsReadyAction: class {
+    createOrUpdateInstructions = mockCreateOrUpdateInstructions;
+    getChannel = mockGetChannel;
+  },
+}));
+
+jest.mock("../../shared/action/ready-action", () => ({
+  readyActionExecutor: jest.fn((action, options) => action.execute()),
+}));
+
+describe("UpdateApplicationInfoAction", () => {
+  let client: Client;
+  let action: UpdateApplicationInfoAction;
+
+  beforeEach(() => {
+    client = asClient(createMockClient());
+    // Create instance using constructor
+    action = new UpdateApplicationInfoAction(client);
+    jest.clearAllMocks();
+  });
+
+  describe("execute", () => {
+    it("should create instructions with volunteer roles embed and button", async () => {
+      await action.execute();
+
+      expect(mockCreateOrUpdateInstructions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          embeds: expect.arrayContaining([
+            expect.objectContaining({
+              data: expect.objectContaining({
+                title: "Volunteer Applications",
+              }),
+            }),
+          ]),
+          components: expect.arrayContaining([
+            expect.objectContaining({
+              components: expect.arrayContaining([
+                expect.objectContaining({
+                  data: expect.objectContaining({
+                    custom_id: "volunteer-application",
+                    label: "Volunteer Application",
+                  }),
+                }),
+              ]),
+            }),
+          ]),
+        }),
+        "applicationInstructions"
+      );
+
+      const call = mockCreateOrUpdateInstructions.mock.calls[0][0];
+
+      // Test embed matches fixture
+      const embed = call.embeds[0];
+      expect(embed).toMatchFixture(volunteerApplicationsEmbed);
+
+      // Test component structure
+      const actionRow = call.components[0];
+      expect(actionRow.components).toHaveLength(1);
+
+      const buttonBuilder = actionRow.components[0];
+      expect(buttonBuilder.data.custom_id).toBe("volunteer-application");
+      expect(buttonBuilder.data.label).toBe("Volunteer Application");
+      expect(buttonBuilder.data.style).toBe(ButtonStyle.Primary);
+    });
+  });
+
+  describe("channel getter", () => {
+    it("should get applications channel with correct ID", () => {
+      // Access the protected property through reflection
+      const channel = (action as any).channel;
+
+      expect(mockGetChannel).toHaveBeenCalledWith("999888777", "applications");
+    });
+  });
+});
+
+describe("updateApplicationInfo", () => {
+  it("should execute UpdateApplicationInfoAction with readyActionExecutor", async () => {
+    const client = asClient(createMockClient());
+    const options = {};
+
+    await updateApplicationInfo(client, options);
+
+    const { readyActionExecutor } = require("../../shared/action/ready-action");
+    expect(readyActionExecutor).toHaveBeenCalledWith(
+      expect.any(UpdateApplicationInfoAction),
+      options
+    );
+  });
+
+  it("should work without options", async () => {
+    const client = asClient(createMockClient());
+
+    await updateApplicationInfo(client);
+
+    const { readyActionExecutor } = require("../../shared/action/ready-action");
+    expect(readyActionExecutor).toHaveBeenCalledWith(
+      expect.any(UpdateApplicationInfoAction),
+      undefined
+    );
+  });
+});

--- a/src/test/helpers/execution-helpers.ts
+++ b/src/test/helpers/execution-helpers.ts
@@ -1,0 +1,15 @@
+import { TestButtonInteraction } from "../mocks/create-mock-button-interaction";
+import { TestClient } from "../mocks/create-mock-client";
+export async function executeButtonCommand(
+  command: { execute: (interaction: TestButtonInteraction) => Promise<void> },
+  interaction: TestButtonInteraction
+): Promise<void> {
+  return command.execute(interaction);
+}
+
+export function executeWithMockClient<T>(
+  fn: (client: TestClient) => T,
+  client: TestClient
+): T {
+  return fn(client);
+}

--- a/src/test/helpers/test-setup.ts
+++ b/src/test/helpers/test-setup.ts
@@ -1,0 +1,41 @@
+import { TestUser, createMockUser } from "../mocks/create-mock-user";
+import { TestGuild, createMockGuild } from "../mocks/create-mock-guild";
+import {
+  TestButtonInteraction,
+  createMockButtonInteraction,
+} from "../mocks/create-mock-button-interaction";
+import { TestThreadChannel } from "../mocks/create-mock-thread-channel";
+
+export interface ApplicationTestSetupOptions {
+  requestDumpThreadId?: string;
+  customId?: string;
+  userId?: string;
+  username?: string;
+}
+
+export function setupApplicationTest({
+  requestDumpThreadId = "111222333",
+  customId = "volunteer-application",
+  userId = "123456789",
+  username = "testuser",
+}: ApplicationTestSetupOptions = {}) {
+  const user = createMockUser({ id: userId, username });
+  const guild = createMockGuild({
+    threadChannels: [{ id: requestDumpThreadId }],
+  });
+  const interaction = createMockButtonInteraction({
+    customId,
+    user,
+    guild,
+  });
+
+  const threadChannel = guild.channels.fetch(requestDumpThreadId);
+
+  return {
+    interaction,
+    guild,
+    user,
+    threadChannel,
+    requestDumpThreadId,
+  };
+}

--- a/src/test/matchers/discord-matchers.ts
+++ b/src/test/matchers/discord-matchers.ts
@@ -1,0 +1,257 @@
+import { expect } from "@jest/globals";
+import {
+  ButtonBuilder,
+  EmbedBuilder,
+  MessageCreateOptions,
+  Message,
+  InteractionResponse,
+} from "discord.js";
+import * as fs from "fs";
+import * as path from "path";
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveSentDm(expectedContent?: string | RegExp): R;
+      toHaveSentMessage(expectedContent?: string | RegExp): R;
+      toHaveLabel(expectedLabel: string): R;
+      toHaveCustomId(expectedCustomId: string): R;
+      toHaveReplied(expectedContent: string | RegExp): R;
+      toHaveEditedReply(expectedContent: string | RegExp): R;
+      toMatchFixture(expectedEmbed: object): R;
+    }
+  }
+}
+
+expect.extend({
+  toHaveSentDm(
+    received: {
+      send: jest.MockedFunction<
+        (options: MessageCreateOptions) => Promise<Message>
+      >;
+    },
+    expectedContent?: string | RegExp
+  ) {
+    const mockSend = received.send;
+
+    if (!mockSend.mock.calls.length) {
+      return {
+        message: () => `Expected user to have sent a DM, but no DM was sent`,
+        pass: false,
+      };
+    }
+
+    if (!expectedContent) {
+      return {
+        message: () => `Expected user to have sent a DM`,
+        pass: true,
+      };
+    }
+
+    const lastCall = mockSend.mock.calls[mockSend.mock.calls.length - 1];
+    const messageOptions = lastCall[0];
+    const actualContent =
+      typeof messageOptions === "string"
+        ? messageOptions
+        : (messageOptions as any)?.content;
+
+    if (!actualContent) {
+      return {
+        message: () =>
+          `Expected user to have sent a DM with content, but no content found`,
+        pass: false,
+      };
+    }
+
+    const contentMatches =
+      typeof expectedContent === "string"
+        ? actualContent === expectedContent
+        : expectedContent.test(actualContent);
+
+    return {
+      message: () =>
+        contentMatches
+          ? `Expected user to not have sent a DM with content matching ${expectedContent}, but it did`
+          : `Expected user to have sent a DM with content matching ${expectedContent}, but received: ${actualContent}`,
+      pass: contentMatches,
+    };
+  },
+
+  toHaveSentMessage(
+    received: {
+      send: jest.MockedFunction<(content: string) => Promise<Message>>;
+    },
+    expectedContent?: string | RegExp
+  ) {
+    const mockSend = received.send;
+
+    if (!mockSend.mock.calls.length) {
+      return {
+        message: () =>
+          `Expected channel to have sent a message, but no message was sent`,
+        pass: false,
+      };
+    }
+
+    if (!expectedContent) {
+      return {
+        message: () => `Expected channel to have sent a message`,
+        pass: true,
+      };
+    }
+
+    const lastCall = mockSend.mock.calls[mockSend.mock.calls.length - 1];
+    const messageOptions = lastCall[0];
+    const actualContent =
+      typeof messageOptions === "string"
+        ? messageOptions
+        : (messageOptions as any)?.content;
+
+    if (!actualContent) {
+      return {
+        message: () =>
+          `Expected channel to have sent a message with content, but no content found`,
+        pass: false,
+      };
+    }
+
+    const contentMatches =
+      typeof expectedContent === "string"
+        ? actualContent === expectedContent
+        : expectedContent.test(actualContent);
+
+    return {
+      message: () =>
+        contentMatches
+          ? `Expected channel to not have sent a message with content matching ${expectedContent}, but it did`
+          : `Expected channel to have sent a message with content matching ${expectedContent}, but received: ${actualContent}`,
+      pass: contentMatches,
+    };
+  },
+
+  toHaveLabel(received: ButtonBuilder, expectedLabel: string) {
+    const actualLabel = received.data.label;
+    const labelMatches = actualLabel === expectedLabel;
+
+    return {
+      message: () =>
+        labelMatches
+          ? `Expected button to not have label "${expectedLabel}", but it did`
+          : `Expected button to have label "${expectedLabel}", but received: "${actualLabel}"`,
+      pass: labelMatches,
+    };
+  },
+
+  toHaveCustomId(
+    received:
+      | ButtonBuilder
+      | { customId: string }
+      | { data: { custom_id: string } },
+    expectedCustomId: string
+  ) {
+    const actualCustomId =
+      "customId" in received
+        ? received.customId
+        : "data" in received
+        ? (received.data as any).custom_id
+        : undefined;
+    const customIdMatches = actualCustomId === expectedCustomId;
+
+    return {
+      message: () =>
+        customIdMatches
+          ? `Expected to not have custom ID "${expectedCustomId}", but it did`
+          : `Expected to have custom ID "${expectedCustomId}", but received: "${actualCustomId}"`,
+      pass: customIdMatches,
+    };
+  },
+
+  toHaveReplied(
+    received: {
+      reply: jest.MockedFunction<
+        (options: { content: string }) => Promise<InteractionResponse>
+      >;
+    },
+    expectedContent: string | RegExp
+  ) {
+    const mockReply = received.reply;
+
+    if (!mockReply.mock.calls.length) {
+      return {
+        message: () =>
+          `Expected interaction to have replied, but no reply was sent`,
+        pass: false,
+      };
+    }
+
+    const lastCall = mockReply.mock.calls[mockReply.mock.calls.length - 1];
+    const actualContent = lastCall[0]?.content || lastCall[0];
+
+    const contentMatches =
+      typeof expectedContent === "string"
+        ? actualContent === expectedContent
+        : expectedContent.test(String(actualContent));
+
+    return {
+      message: () =>
+        contentMatches
+          ? `Expected interaction to not have replied with content matching ${expectedContent}, but it did`
+          : `Expected interaction to have replied with content matching ${expectedContent}, but received: ${actualContent}`,
+      pass: contentMatches,
+    };
+  },
+
+  toHaveEditedReply(
+    received: {
+      editReply: jest.MockedFunction<
+        (options: { content: string }) => Promise<Message>
+      >;
+    },
+    expectedContent: string | RegExp
+  ) {
+    const mockEditReply = received.editReply;
+
+    if (!mockEditReply.mock.calls.length) {
+      return {
+        message: () =>
+          `Expected interaction to have edited a reply, but no edit-reply was sent`,
+        pass: false,
+      };
+    }
+
+    const lastCall =
+      mockEditReply.mock.calls[mockEditReply.mock.calls.length - 1];
+    const actualContent = lastCall[0]?.content || lastCall[0];
+
+    const contentMatches =
+      typeof expectedContent === "string"
+        ? actualContent === expectedContent
+        : expectedContent.test(String(actualContent));
+
+    return {
+      message: () =>
+        contentMatches
+          ? `Expected interaction to not have edited a reply with content matching ${expectedContent}, but it did`
+          : `Expected interaction to have edited a reply with content matching ${expectedContent}, but received: ${actualContent}`,
+      pass: contentMatches,
+    };
+  },
+
+  toMatchFixture(received: EmbedBuilder, expectedEmbed: object) {
+    const actualEmbed = received.toJSON();
+    const embedsMatch =
+      JSON.stringify(expectedEmbed) === JSON.stringify(actualEmbed);
+
+    return {
+      message: () =>
+        embedsMatch
+          ? `Expected embed to not match fixture, but it did`
+          : `Expected embed to match fixture\n\nExpected:\n${JSON.stringify(
+              expectedEmbed,
+              null,
+              2
+            )}\n\nReceived:\n${JSON.stringify(actualEmbed, null, 2)}`,
+      pass: embedsMatch,
+    };
+  },
+});

--- a/src/test/mocks/create-mock-button-interaction.ts
+++ b/src/test/mocks/create-mock-button-interaction.ts
@@ -1,0 +1,55 @@
+import {
+  ButtonInteraction,
+  CacheType,
+  Message,
+  InteractionResponse,
+} from "discord.js";
+import { jest } from "@jest/globals";
+import { createTypedMock } from "../utils/mock-helpers";
+import { TestUser, createMockUser } from "./create-mock-user";
+import { TestClient, createMockClient } from "./create-mock-client";
+import { TestGuild, createMockGuild } from "./create-mock-guild";
+
+export type TestButtonInteraction = Pick<
+  ButtonInteraction<CacheType>,
+  "customId"
+> & {
+  editReply: jest.MockedFunction<
+    (options: { content: string }) => Promise<Message>
+  >;
+  reply: jest.MockedFunction<
+    (options: { content: string }) => Promise<InteractionResponse>
+  >;
+  deferReply: jest.MockedFunction<() => Promise<InteractionResponse>>;
+  user: TestUser;
+  guild: TestGuild;
+  client: TestClient;
+};
+
+export interface MockButtonInteractionOptions {
+  customId?: string;
+  user?: TestUser;
+  guild?: TestGuild;
+  client?: TestClient;
+}
+
+export function createMockButtonInteraction({
+  customId = "test-button",
+  user = createMockUser(),
+  client = createMockClient(),
+  guild = createMockGuild(),
+}: MockButtonInteractionOptions = {}): TestButtonInteraction {
+  return {
+    customId,
+    user,
+    guild,
+    client,
+    editReply:
+      createTypedMock<(options: { content: string }) => Promise<Message>>(),
+    reply:
+      createTypedMock<
+        (options: { content: string }) => Promise<InteractionResponse>
+      >(),
+    deferReply: createTypedMock<() => Promise<InteractionResponse>>(),
+  };
+}

--- a/src/test/mocks/create-mock-client.ts
+++ b/src/test/mocks/create-mock-client.ts
@@ -1,0 +1,19 @@
+import { Client } from "discord.js";
+
+export type TestClient = {
+  user: { id: string };
+};
+
+export interface MockClientOptions {
+  id?: string;
+}
+
+export function createMockClient({
+  id = "bot123456",
+}: MockClientOptions = {}): TestClient {
+  return {
+    user: {
+      id,
+    },
+  };
+}

--- a/src/test/mocks/create-mock-guild.ts
+++ b/src/test/mocks/create-mock-guild.ts
@@ -1,0 +1,61 @@
+import { Guild, TextChannel, PublicThreadChannel } from "discord.js";
+import { jest } from "@jest/globals";
+import { createTypedMockWithImplementation } from "../utils/mock-helpers";
+import {
+  TestTextChannel,
+  createMockTextChannel,
+} from "./create-mock-text-channel";
+import {
+  TestThreadChannel,
+  createMockThreadChannel,
+} from "./create-mock-thread-channel";
+
+export type TestGuild = Pick<Guild, "id"> & {
+  channels: {
+    fetch: jest.MockedFunction<
+      (channelId: string) => Promise<TextChannel | PublicThreadChannel | null>
+    >;
+  };
+};
+
+export interface MockGuildOptions {
+  id?: string;
+  textChannels?: Array<{ id: string; channel?: TestTextChannel }>;
+  threadChannels?: Array<{ id: string; channel?: TestThreadChannel }>;
+}
+
+export function createMockGuild({
+  id = "444555666",
+  textChannels = [],
+  threadChannels = [],
+}: MockGuildOptions = {}): TestGuild {
+  const channelMap = new Map<string, TestTextChannel | TestThreadChannel>();
+
+  textChannels.forEach(({ id: channelId, channel }) => {
+    channelMap.set(
+      channelId,
+      channel || createMockTextChannel({ id: channelId })
+    );
+  });
+
+  threadChannels.forEach(({ id: channelId, channel }) => {
+    channelMap.set(
+      channelId,
+      channel || createMockThreadChannel({ id: channelId })
+    );
+  });
+
+  const fetchMock = createTypedMockWithImplementation<
+    (channelId: string) => Promise<TextChannel | PublicThreadChannel | null>
+  >((channelId: any) => {
+    const channel = channelMap.get(channelId);
+    return Promise.resolve(channel || null);
+  });
+
+  return {
+    id,
+    channels: {
+      fetch: fetchMock,
+    },
+  };
+}

--- a/src/test/mocks/create-mock-text-channel.ts
+++ b/src/test/mocks/create-mock-text-channel.ts
@@ -1,0 +1,23 @@
+import { TextChannel, ChannelType, Message } from "discord.js";
+import { jest } from "@jest/globals";
+import { createTypedMock } from "../utils/mock-helpers";
+
+export type TestTextChannel = Pick<TextChannel, "id" | "type"> & {
+  send: jest.MockedFunction<(content: string) => Promise<Message>>;
+};
+
+export interface MockChannelOptions {
+  id?: string;
+  type?: ChannelType;
+}
+
+export function createMockTextChannel({
+  id = "987654321",
+  type = ChannelType.GuildText,
+}: MockChannelOptions = {}): TestTextChannel {
+  return {
+    id,
+    type: ChannelType.GuildText,
+    send: createTypedMock<(content: string) => Promise<Message>>(),
+  };
+}

--- a/src/test/mocks/create-mock-thread-channel.ts
+++ b/src/test/mocks/create-mock-thread-channel.ts
@@ -1,0 +1,23 @@
+import { PublicThreadChannel, ChannelType, Message } from "discord.js";
+import { jest } from "@jest/globals";
+import { createTypedMock } from "../utils/mock-helpers";
+
+export type TestThreadChannel = Pick<PublicThreadChannel, "id" | "type"> & {
+  send: jest.MockedFunction<(content: string) => Promise<Message>>;
+};
+
+export interface MockChannelOptions {
+  id?: string;
+  type?: ChannelType;
+}
+
+export function createMockThreadChannel({
+  id = "111222333",
+  type = ChannelType.PublicThread,
+}: MockChannelOptions = {}): TestThreadChannel {
+  return {
+    id,
+    type: ChannelType.PublicThread,
+    send: createTypedMock<(content: string) => Promise<Message>>(),
+  };
+}

--- a/src/test/mocks/create-mock-user.ts
+++ b/src/test/mocks/create-mock-user.ts
@@ -1,0 +1,27 @@
+import { User, MessageCreateOptions, Message } from "discord.js";
+import { jest } from "@jest/globals";
+import { createTypedMock } from "../utils/mock-helpers";
+
+export type TestUser = Pick<User, "id" | "username"> & {
+  send: jest.MockedFunction<
+    (options: MessageCreateOptions) => Promise<Message>
+  >;
+};
+
+export interface MockUserOptions {
+  id?: string;
+  username?: string;
+}
+
+export function createMockUser({
+  id = "123456789",
+  username = "testuser",
+}: MockUserOptions = {}): TestUser {
+  return {
+    id,
+    username,
+    send: createTypedMock<
+      (options: MessageCreateOptions) => Promise<Message>
+    >(),
+  };
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "./matchers/discord-matchers";

--- a/src/test/utils/discord-conversions.ts
+++ b/src/test/utils/discord-conversions.ts
@@ -1,0 +1,13 @@
+import { Client, ButtonInteraction, CacheType } from "discord.js";
+import type { TestClient } from "../mocks/create-mock-client";
+import type { TestButtonInteraction } from "../mocks/create-mock-button-interaction";
+
+export function asClient(mock: TestClient): Client {
+  return mock as unknown as Client;
+}
+
+export function asButtonInteraction(
+  mock: TestButtonInteraction
+): ButtonInteraction<CacheType> {
+  return mock as unknown as ButtonInteraction<CacheType>;
+}

--- a/src/test/utils/mock-helpers.ts
+++ b/src/test/utils/mock-helpers.ts
@@ -1,0 +1,15 @@
+import { jest } from "@jest/globals";
+
+export function createTypedMock<
+  T extends (...args: any[]) => any
+>(): jest.MockedFunction<T> {
+  return jest.fn() as unknown as jest.MockedFunction<T>;
+}
+
+export function createTypedMockWithImplementation<
+  T extends (...args: any[]) => any
+>(implementation: (...args: any[]) => any): jest.MockedFunction<T> {
+  return jest
+    .fn()
+    .mockImplementation(implementation) as unknown as jest.MockedFunction<T>;
+}


### PR DESCRIPTION
- Split monolithic discord-mocks.ts into focused, co-located files
- Created reusable mock helpers with proper Jest typing
- Implemented Pick<> types for Discord.js property inheritance
- Added type-safe conversion functions with controlled assertions
- Organized structure: utils/, mocks/, matchers/, helpers/
- Eliminated type casts and 'any' usage where possible
- Added comprehensive tests for applications feature

🤖 Generated with [Claude Code](https://claude.ai/code)