### PR TITLE
Add noBotWizardsRoleId to block Wizard bot checkouts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ export const {
   raiderRoleId,
   inactiveRaiderRoleId,
   noBotsRoleId,
+  noBotWizardsRoleId,
   knightRoleId,
   trackerRoleId,
   reinforcementsRoleId,
@@ -218,6 +219,7 @@ export const {
   inactiveRaiderRoleId: string;
   reinforcementsRoleId: string;
   noBotsRoleId: string;
+  noBotWizardsRoleId: string;
 
   // Guild role IDs
   membersAndAlliesRoleId: string;

--- a/src/services/bot/bot-prisma.ts
+++ b/src/services/bot/bot-prisma.ts
@@ -26,7 +26,8 @@ import { ParkBotButtonCommand } from "../../features/raid-bots/park-bot-button-c
 import { refreshBotEmbed } from "../../features/raid-bots/bot-embed";
 import { code } from "../../shared/util";
 import { MINUTES } from "../../shared/time";
-import { noBotsRoleId } from "../../config";
+import { noBotsRoleId, noBotWizardsRoleId } from "../../config";
+import { Class } from "../../shared/classes";
 
 export class PrismaPublicAccounts implements IPublicAccountService {
   private refreshing: boolean = false;
@@ -144,6 +145,9 @@ export class PrismaPublicAccounts implements IPublicAccountService {
 
       const foundBot = details.characters;
       const prismaBot = await this.getBotByName(foundBot);
+      if (prismaBot?.class === Class.Wizard && roles.cache.has(noBotWizardsRoleId)) {
+        throw new Error("You do not have permission to request Wizard bots");
+      }
       const currentPilot = await this.getCurrentBotPilot(foundBot);
 
       const factionWarning = `${code}diff
@@ -246,6 +250,9 @@ Password: ${spoiler(details.password)}
     bindLocation?: string | undefined
   ): Promise<string> {
     await this.guardReady();
+    if (botClass === Class.Wizard && roles.cache.has(noBotWizardsRoleId)) {
+      throw new Error(`You do not have permission to request a ${botClass}`);
+    }
     const bot = await prismaClient.bot.findFirst({
       where: {
         class: botClass,

--- a/src/services/bot/public-accounts-sheet.ts
+++ b/src/services/bot/public-accounts-sheet.ts
@@ -2,8 +2,10 @@ import { GoogleSpreadsheet } from "google-spreadsheet";
 import {
   GOOGLE_CLIENT_EMAIL,
   GOOGLE_PRIVATE_KEY,
+  noBotWizardsRoleId,
   publicCharactersGoogleSheetId,
 } from "../../config";
+import { Class } from "../../shared/classes";
 import LRUCache from "lru-cache";
 import { MINUTES } from "../../shared/time";
 import {
@@ -166,6 +168,9 @@ export class SheetPublicAccountService implements IPublicAccountService {
     roles: GuildMemberRoleManager,
     location?: string
   ) {
+    if (botClass === Class.Wizard && roles.cache.has(noBotWizardsRoleId)) {
+      throw new Error(`You do not have permission to request a ${botClass}`);
+    }
     await this.loadBots();
     if (this.sheet) {
       const rows = await this.botInfoSheet.getRows();


### PR DESCRIPTION
## Summary
- Add a new `noBotWizardsRoleId` config, mirroring the existing `noBotsRoleId`.
- Block a checkout when the requested bot's class is Wizard and the requester holds `noBotWizardsRoleId`, in both `/bot request <name>` (checked once the bot's class is resolved) and `/bot requestclass Wizard` (checked up front against the requested class).
- Applied to both account service implementations (`PrismaPublicAccounts` and `SheetPublicAccountService`) since either can be active depending on `USE_PRISMA_CACHE`.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Set `noBotWizardsRoleId` in the environment, grant it to a test account, and confirm `/bot request <a Wizard bot>` and `/bot requestclass Wizard` are denied while other classes remain checkout-able
- [ ] Confirm `noBotsRoleId` behavior (blocking all bots) is unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01AaBjES2LZ7k8PY3boMMJny)_