### PR TITLE
Only deliver EQNotify alerts to active Raiders

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Some features required secrets, such as to connect to CastleDKP.com or the Castl
 
 #### 📣 EQNotify
 
-`/eqnotify` lets raiders subscribe to phone notifications for the raid targets they care about. It watches the batphone channel and, for each subscriber whose keyword tags match the batphone (buff / last-hour RTE calls are filtered out), pushes an alert to their phone.
+`/eqnotify` lets raiders subscribe to phone notifications for the raid targets they care about. It watches the batphone channel and, for each subscriber whose keyword tags match the batphone (buff / last-hour RTE calls are filtered out), pushes an alert to their phone. Alerts are only delivered to subscribers who **currently hold the Raider role**, so anyone who goes inactive or leaves stops receiving them automatically.
 
 - **Delivery channels**: **WirePusher** (free, Android-only) or **Telegram** (iOS/Android/desktop). Telegram delivery requires `TELEGRAM_BOT_TOKEN`; if unset, only WirePusher is offered.
 - **Getting your ID**: WirePusher users use their device ID from the app. Telegram users start a chat with the guild's EQNotify bot and get their numeric chat ID (e.g. from [@userinfobot](https://t.me/userinfobot)).

--- a/src/features/eqnotify/commands/register-subcommand.ts
+++ b/src/features/eqnotify/commands/register-subcommand.ts
@@ -46,7 +46,7 @@ class RegisterSubcommand extends Subcommand {
         ? `Updated your EQNotify delivery to **${channel}**. Your notification tags are unchanged.`
         : `You're enrolled in EQNotify via **${channel}**! You'll be notified for: ${DEFAULT_TAGS.join(
             ", "
-          )}.\nUse \`/eqnotify add-tag\` / \`/eqnotify remove-tag\` to customize, and \`/eqnotify test\` to verify delivery.`
+          )}.\nUse \`/eqnotify add-tag\` / \`/eqnotify remove-tag\` to customize, and \`/eqnotify test\` to verify delivery.\n_Note: alerts are only sent while you actively hold the Raider role._`
     );
   }
 

--- a/src/features/eqnotify/eqnotify.service.ts
+++ b/src/features/eqnotify/eqnotify.service.ts
@@ -1,5 +1,6 @@
 import { eqnotify_subscriber, eqnotify_type } from "@prisma/client";
-import { prismaClient } from "../..";
+import { getMember, prismaClient } from "../..";
+import { raiderRoleId } from "../../config";
 import { log } from "../../shared/logger";
 import { notify } from "./notifiers";
 import {
@@ -17,6 +18,24 @@ interface EnrollInput {
   contact: string;
   type: eqnotify_type;
 }
+
+/**
+ * Whether a member currently holds the Raider role. Batphone alerts are only
+ * delivered to active Raiders, so a subscriber who loses the role (goes
+ * inactive, leaves the guild, etc.) stops receiving alerts without having to
+ * unregister. Failures to resolve the member are treated as "not a Raider".
+ */
+const hasRaiderRole = async (discordId: string): Promise<boolean> => {
+  try {
+    const member = await getMember(discordId);
+    return member.roles.cache.has(raiderRoleId);
+  } catch (error) {
+    log(
+      `EQNotify could not resolve member ${discordId} for role check: ${error}`
+    );
+    return false;
+  }
+};
 
 const requireSubscriber = async (discordId: string) => {
   const subscriber = await prismaClient.eqnotify_subscriber.findUnique({
@@ -95,7 +114,8 @@ export const eqnotifyService = {
 
   /**
    * Matches a batphone against every subscriber's tags and delivers alerts.
-   * Delivery failures are logged but never interrupt other subscribers.
+   * Only subscribers who currently hold the Raider role are notified. Delivery
+   * failures are logged but never interrupt other subscribers.
    */
   dispatch: async (content: string) => {
     if (!content.trim() || isFiltered(content)) {
@@ -105,7 +125,12 @@ export const eqnotifyService = {
     await Promise.all(
       subscribers
         .filter((sub) => matchesTags(content, sub.tags))
-        .map((sub) => eqnotifyService.notifySubscriber(sub, content))
+        .map(async (sub) => {
+          if (!(await hasRaiderRole(sub.discordId))) {
+            return;
+          }
+          await eqnotifyService.notifySubscriber(sub, content);
+        })
     );
   },
 


### PR DESCRIPTION
## Summary

Follow-up to #263 (EQNotify). Gates batphone dispatch on the subscriber **currently holding the Raider role**, checked live against Discord at push time.

A subscriber who loses the role (goes inactive, leaves the guild, etc.) stops receiving alerts without having to `unregister`. Members that can't be resolved (e.g. they've left) are treated as non-Raiders and skipped.

## Changes

- `dispatch()` now resolves each tag-matching subscriber via `getMember()` and only delivers if they hold `raiderRoleId`. Failures to resolve are fail-closed.
- Scope: applies only to the batphone dispatch path. The manual `/eqnotify test` command is intentionally unaffected, since it's a self-check that a user's device/chat ID works.
- Surfaced the requirement in the `/eqnotify register` confirmation and the README.

## Testing

- `yarn tsc` — clean.
- `yarn test:ci` (eqnotify matcher suite) — 11 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWXRmPbtEz35wquwFd8Cu7)_