### PR TITLE
Fix EQNotify add-tag description exceeding Discord's 100-char limit (boot crash)

### DIFF
--- a/src/features/eqnotify/commands/add-tag-subcommand.ts
+++ b/src/features/eqnotify/commands/add-tag-subcommand.ts
@@ -23,8 +23,9 @@ class AddTagSubcommand extends Subcommand {
     return super.command.addStringOption((o) =>
       o
         .setName(Option.Tag)
+        // Discord limits option descriptions to 100 characters; keep it short.
         .setDescription(
-          "Keyword to match at the start of a batphone word (e.g. 'doze' hits 'Dozekar'). Use 'all' for every batphone."
+          "Keyword matched at the start of a batphone word (e.g. 'doze' hits Dozekar). 'all' = every BP."
         )
         .setRequired(true)
     );


### PR DESCRIPTION
## Problem

The bot crashes on boot during slash-command registration:

```
ExpectedConstraintError: Invalid string length
  constraint: 's.string().lengthLessThanOrEqual()',
  given: "Keyword to match at the start of a batphone word (e.g. 'doze' hits 'Dozekar'). Use 'all' for every batphone.",
  expected: 'expected.length <= 100'
  at ... add-tag-subcommand.js:19 (setDescription)
```

Discord caps slash-command **option descriptions at 100 characters**. The `/eqnotify add-tag` description added in #266 was **108 characters**. discord.js only validates this at command-registration time (not compile time), so it passed `tsc` and the unit tests but took down the worker on deploy.

## Fix

- Shortened the description to **93 characters**, keeping the `doze`→Dozekar hint:
  `Keyword matched at the start of a batphone word (e.g. 'doze' hits Dozekar). 'all' = every BP.`
- Added an inline comment noting the 100-char cap.
- Audited every other EQNotify command/subcommand/option description — all are already within the limit; `add-tag` was the only offender.

## Testing

- `yarn tsc` — clean.
- Verified the new literal is 93 chars (≤ 100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWXRmPbtEz35wquwFd8Cu7)_